### PR TITLE
Add Text.Blaze.Event.Internal to the cabal file

### DIFF
--- a/blaze-react.cabal
+++ b/blaze-react.cabal
@@ -39,6 +39,7 @@ library
                        Text.Blaze.Event.Keycode
                        Text.Blaze.Event.Charcode
 
+                       Text.Blaze.Event.Internal
                        Text.Blaze.Internal
 
                        Blaze.React


### PR DESCRIPTION
@asayers I'm not sure `Text.Blaze.Event.Internal` needs to be exposed. If not you can add it to the `other-modules`.
